### PR TITLE
Add Weather Content Provider [5/5]

### DIFF
--- a/packages/SystemUI/AndroidManifest.xml
+++ b/packages/SystemUI/AndroidManifest.xml
@@ -135,9 +135,6 @@
             android:protectionLevel="signature" />
     <uses-permission android:name="com.android.systemui.permission.SELF" />
 
-    <!-- Weather -->
-    <uses-permission android:name="com.cyanogenmod.lockclock.permission.READ_WEATHER" />
-
     <!-- blur surface -->
     <uses-permission android:name="android.permission.ACCESS_SURFACE_FLINGER" />
 

--- a/packages/SystemUI/AndroidManifest_cm.xml
+++ b/packages/SystemUI/AndroidManifest_cm.xml
@@ -47,6 +47,9 @@
     <!-- Live lock screen manager -->
     <uses-permission android:name="cyanogenmod.permission.LIVE_LOCK_SCREEN_MANAGER_ACCESS_PRIVATE" />
 
+     <!-- Weather Provider -->
+    <uses-permission android:name="cyanogenmod.permission.READ_WEATHER" />
+
     <application>
         <provider android:name=".cm.SpamMessageProvider"
                   android:permission="android.permission.INTERACT_ACROSS_USERS_FULL"

--- a/packages/SystemUI/src/com/android/systemui/statusbar/policy/WeatherControllerImpl.java
+++ b/packages/SystemUI/src/com/android/systemui/statusbar/policy/WeatherControllerImpl.java
@@ -16,43 +16,42 @@
 
 package com.android.systemui.statusbar.policy;
 
-import android.content.BroadcastReceiver;
 import android.content.ComponentName;
-import android.content.ContentResolver;
 import android.content.Context;
 import android.content.Intent;
-import android.content.IntentFilter;
 import android.database.ContentObserver;
 import android.database.Cursor;
-import android.net.Uri;
 import android.os.Handler;
-import android.provider.Settings;
 import android.util.Log;
+import cyanogenmod.providers.WeatherContract;
+import cyanogenmod.weather.util.WeatherUtils;
 
 import java.util.ArrayList;
+
+import static cyanogenmod.providers.WeatherContract.WeatherColumns.CURRENT_CITY;
+import static cyanogenmod.providers.WeatherContract.WeatherColumns.CURRENT_CONDITION;
+import static cyanogenmod.providers.WeatherContract.WeatherColumns.CURRENT_TEMPERATURE;
+import static cyanogenmod.providers.WeatherContract.WeatherColumns.CURRENT_TEMPERATURE_UNIT;
 
 public class WeatherControllerImpl implements WeatherController {
 
     private static final String TAG = WeatherController.class.getSimpleName();
     private static final boolean DEBUG = Log.isLoggable(TAG, Log.DEBUG);
+    private WeatherContentObserver mWeatherContentObserver;
+    private Handler mHandler;
 
     public static final ComponentName COMPONENT_WEATHER_FORECAST = new ComponentName(
             "com.cyanogenmod.lockclock", "com.cyanogenmod.lockclock.weather.ForecastActivity");
-    public static final String ACTION_UPDATE_FINISHED
-            = "com.cyanogenmod.lockclock.action.WEATHER_UPDATE_FINISHED";
-    public static final String EXTRA_UPDATE_CANCELLED = "update_cancelled";
     public static final String ACTION_FORCE_WEATHER_UPDATE
             = "com.cyanogenmod.lockclock.action.FORCE_WEATHER_UPDATE";
-    public static final Uri CURRENT_WEATHER_URI
-            = Uri.parse("content://com.cyanogenmod.lockclock.weather.provider/weather/current");
-    public static final String[] WEATHER_PROJECTION = new String[]{
-            "temperature",
-            "city",
-            "condition"
+    private static final String[] WEATHER_PROJECTION = new String[]{
+            CURRENT_TEMPERATURE,
+            CURRENT_TEMPERATURE_UNIT,
+            CURRENT_CITY,
+            CURRENT_CONDITION
     };
 
     private final ArrayList<Callback> mCallbacks = new ArrayList<Callback>();
-    private final Receiver mReceiver = new Receiver();
     private final Context mContext;
 
     private WeatherInfo mCachedInfo = new WeatherInfo();
@@ -60,10 +59,12 @@ public class WeatherControllerImpl implements WeatherController {
     public WeatherControllerImpl(Context context) {
         mContext = context;
                 mContext.getSystemService(Context.CONNECTIVITY_SERVICE);
+        mHandler = new Handler();
+        mWeatherContentObserver = new WeatherContentObserver(mHandler);
+        mContext.getContentResolver().registerContentObserver(
+                WeatherContract.WeatherColumns.CURRENT_WEATHER_URI,
+                true, mWeatherContentObserver);
         queryWeather();
-        final IntentFilter filter = new IntentFilter();
-        filter.addAction(ACTION_UPDATE_FINISHED);
-        mContext.registerReceiver(mReceiver, filter);
     }
 
     public void addCallback(Callback callback) {
@@ -85,17 +86,20 @@ public class WeatherControllerImpl implements WeatherController {
     }
 
     private void queryWeather() {
-        Cursor c = mContext.getContentResolver().query(CURRENT_WEATHER_URI, WEATHER_PROJECTION,
+        Cursor c = mContext.getContentResolver().query(
+                WeatherContract.WeatherColumns.CURRENT_WEATHER_URI, WEATHER_PROJECTION,
                 null, null, null);
         if (c == null) {
             if(DEBUG) Log.e(TAG, "cursor was null for temperature, forcing weather update");
+            //LockClock keeps track of the user settings (temp unit, search by geo location/city)
+            //so we delegate the responsibility of handling a weather update to LockClock
             mContext.sendBroadcast(new Intent(ACTION_FORCE_WEATHER_UPDATE));
         } else {
             try {
                 c.moveToFirst();
-                mCachedInfo.temp = c.getString(0);
-                mCachedInfo.city = c.getString(1);
-                mCachedInfo.condition = c.getString(2);
+                mCachedInfo.temp = WeatherUtils.formatTemperature(c.getDouble(0), c.getInt(1));
+                mCachedInfo.city = c.getString(2);
+                mCachedInfo.condition = c.getString(3);
             } finally {
                 c.close();
             }
@@ -108,19 +112,18 @@ public class WeatherControllerImpl implements WeatherController {
         }
     }
 
-    private final class Receiver extends BroadcastReceiver {
+    private final class WeatherContentObserver extends ContentObserver {
+
+        public WeatherContentObserver(Handler handler) {
+            super(handler);
+        }
+
         @Override
-        public void onReceive(Context context, Intent intent) {
-            if (DEBUG) Log.d(TAG, "onReceive " + intent.getAction());
-            if (intent.hasExtra(EXTRA_UPDATE_CANCELLED)) {
-                if (intent.getBooleanExtra(EXTRA_UPDATE_CANCELLED, false)) {
-                    // no update
-                    return;
-                }
-            }
+        public void onChange(boolean selfChange) {
+            super.onChange(selfChange);
+            if (DEBUG) Log.d(TAG, "Received onChange notification");
             queryWeather();
             fireCallback();
         }
     }
-
 }


### PR DESCRIPTION
Use the Weather Content Provider in the cmsdk to pull the
weather data.

However, SystemUI will rely on LockClock to force weather
updates via the new Weather Service, which in turn will
send a broadcast when new weather data is available.

Change-Id: I3c65ea5f4cc297a7944fcdef33f496cdf2d68d0a