### PR TITLE
media: Remove effect session callbacks from the framework

### DIFF
--- a/core/jni/android_media_AudioSystem.cpp
+++ b/core/jni/android_media_AudioSystem.cpp
@@ -154,11 +154,6 @@ static struct {
     jmethodID postDynPolicyEventFromNative;
 } gDynPolicyEventHandlerMethods;
 
-static struct {
-    jmethodID postEffectSessionEventFromNative;
-} gEffectSessionEventHandlerMethods;
-
-
 static Mutex gLock;
 
 enum AudioError {
@@ -387,25 +382,6 @@ android_media_AudioSystem_dyn_policy_callback(int event, String8 regId, int val)
             event, zestring, val);
 
     env->ReleaseStringUTFChars(zestring, zechars);
-    env->DeleteLocalRef(clazz);
-
-}
-
-static void
-android_media_AudioSystem_effect_session_callback(int event, audio_stream_type_t stream,
-        audio_unique_id_t sessionId, audio_output_flags_t flags,
-        audio_channel_mask_t channelMask, uid_t uid, bool added)
-{
-    JNIEnv *env = AndroidRuntime::getJNIEnv();
-    if (env == NULL) {
-        return;
-    }
-
-    jclass clazz = env->FindClass(kClassPathName);
-
-    env->CallStaticVoidMethod(clazz, gEffectSessionEventHandlerMethods.postEffectSessionEventFromNative,
-            event, stream, sessionId, flags, channelMask, uid, added);
-
     env->DeleteLocalRef(clazz);
 
 }
@@ -1511,12 +1487,6 @@ android_media_AudioSystem_registerDynPolicyCallback(JNIEnv *env, jobject thiz)
     AudioSystem::setDynPolicyCallback(android_media_AudioSystem_dyn_policy_callback);
 }
 
-static void
-android_media_AudioSystem_registerEffectSessionCallback(JNIEnv *env, jobject thiz)
-{
-    AudioSystem::setEffectSessionCallback(android_media_AudioSystem_effect_session_callback);
-}
-
 
 static jint convertAudioMixToNative(JNIEnv *env,
                                     AudioMix *nAudioMix,
@@ -1689,8 +1659,6 @@ static JNINativeMethod gMethods[] = {
                                             (void *)android_media_AudioSystem_registerPolicyMixes},
     {"native_register_dynamic_policy_callback", "()V",
                                     (void *)android_media_AudioSystem_registerDynPolicyCallback},
-    {"native_register_effect_session_callback", "()V",
-                                    (void *)android_media_AudioSystem_registerEffectSessionCallback},
     {"systemReady", "()I", (void *)android_media_AudioSystem_systemReady},
 };
 
@@ -1797,10 +1765,6 @@ int register_android_media_AudioSystem(JNIEnv *env)
     gDynPolicyEventHandlerMethods.postDynPolicyEventFromNative =
             GetStaticMethodIDOrDie(env, env->FindClass(kClassPathName),
                     "dynamicPolicyCallbackFromNative", "(ILjava/lang/String;I)V");
-
-    gEffectSessionEventHandlerMethods.postEffectSessionEventFromNative =
-            GetStaticMethodIDOrDie(env, env->FindClass(kClassPathName),
-                    "effectSessionCallbackFromNative", "(IIIIIIZ)V");
 
     jclass audioMixClass = FindClassOrDie(env, "android/media/audiopolicy/AudioMix");
     gAudioMixClass = MakeGlobalRefOrDie(env, audioMixClass);

--- a/media/java/android/media/AudioSystem.java
+++ b/media/java/android/media/AudioSystem.java
@@ -268,55 +268,6 @@ public class AudioSystem
     }
 
 
-   /**
-     * Handles events for the audio policy manager about effect sessions
-     * @see android.media.audiopolicy.AudioPolicy
-     */
-    public interface EffectSessionCallback
-    {
-        void onSessionAdded(int stream, int sessionId, int flags, int channelMask, int uid);
-
-        void onSessionRemoved(int stream, int sessionId);
-    }
-
-    //keep in sync with include/media/AudioPolicy.h
-    private final static int AUDIO_OUTPUT_SESSION_EFFECTS_UPDATE = 10;
-
-    private static EffectSessionCallback sEffectSessionCallback;
-
-    public static void setEffectSessionCallback(EffectSessionCallback cb)
-    {
-        synchronized (AudioSystem.class) {
-            sEffectSessionCallback = cb;
-            native_register_effect_session_callback();
-        }
-    }
-
-    private static void effectSessionCallbackFromNative(int event, int stream, int sessionId,
-            int flags, int channelMask, int uid, boolean added)
-    {
-        EffectSessionCallback cb = null;
-        synchronized (AudioSystem.class) {
-            if (sEffectSessionCallback != null) {
-                cb = sEffectSessionCallback;
-            }
-        }
-        if (cb != null) {
-            switch(event) {
-                case AUDIO_OUTPUT_SESSION_EFFECTS_UPDATE:
-                    if (added) {
-                        cb.onSessionAdded(stream, sessionId, flags, channelMask, uid);
-                    } else {
-                        cb.onSessionRemoved(stream, sessionId);
-                    }
-                    break;
-                default:
-                    Log.e(TAG, "effectSessionCallbackFromNative: unknown event " + event);
-            }
-        }
-    }
-
-
     /*
      * Error codes used by public APIs (AudioTrack, AudioRecord, AudioManager ...)
      * Must be kept in sync with frameworks/base/core/jni/android_media_AudioErrors.h
@@ -696,8 +647,6 @@ public class AudioSystem
 
     // declare this instance as having a dynamic policy callback handler
     private static native final void native_register_dynamic_policy_callback();
-
-    private static native final void native_register_effect_session_callback();
 
     // must be kept in sync with value in include/system/audio.h
     public static final int AUDIO_HW_SYNC_INVALID = 0;


### PR DESCRIPTION
 * This API is moving to CMSDK.

Revert "media: Add flags, channelMask, and UID to audio session callbacks"

This reverts commit e0554d493e870ea5e323ed06f54becb93c19fa04.

Revert "audiosystem: Add API for listening to effect session events"

This reverts commit 9957394df71db6f01802091858216582c58eab67.

Change-Id: I5f18fdb3390db25285a5b819dfe2136ae111c0b3