### PR TITLE
Themes: Expose manifest styles for framework activities

### DIFF
--- a/core/res/AndroidManifest.xml
+++ b/core/res/AndroidManifest.xml
@@ -2815,7 +2815,7 @@
                 android:label="@string/managed_profile_label">
         </activity-alias>
         <activity android:name="com.android.internal.app.HeavyWeightSwitcherActivity"
-                android:theme="@style/Theme.Material.Light.Dialog"
+                android:theme="@style/Theme.Material.Light.Dialog.HeavyWeightSwitcherActivity"
                 android:label="@string/heavy_weight_switcher_title"
                 android:finishOnCloseSystemDialogs="true"
                 android:excludeFromRecents="true"
@@ -2848,7 +2848,7 @@
         <activity android:name="android.accounts.ChooseAccountActivity"
                 android:excludeFromRecents="true"
                 android:exported="true"
-                android:theme="@style/Theme.Material.Light.Dialog"
+                android:theme="@style/Theme.Material.Light.Dialog.ChooseAccountActivity"
                 android:label="@string/choose_account_label"
                 android:process=":ui">
         </activity>
@@ -2856,14 +2856,14 @@
         <activity android:name="android.accounts.ChooseTypeAndAccountActivity"
                 android:excludeFromRecents="true"
                 android:exported="true"
-                android:theme="@style/Theme.Material.Light.Dialog"
+                android:theme="@style/Theme.Material.Light.Dialog.ChooseTypeAndAccountActivity"
                 android:label="@string/choose_account_label"
                 android:process=":ui">
         </activity>
 
         <activity android:name="android.accounts.ChooseAccountTypeActivity"
                 android:excludeFromRecents="true"
-                android:theme="@style/Theme.Material.Light.Dialog"
+                android:theme="@style/Theme.Material.Light.Dialog.ChooseAccountTypeActivity"
                 android:label="@string/choose_account_label"
                 android:process=":ui">
         </activity>
@@ -2871,19 +2871,19 @@
         <activity android:name="android.accounts.CantAddAccountActivity"
                 android:excludeFromRecents="true"
                 android:exported="true"
-                android:theme="@style/Theme.Material.Light.Dialog.NoActionBar"
+                android:theme="@style/Theme.Material.Light.Dialog.NoActionBar.CantAddAccountActivity"
                 android:process=":ui">
         </activity>
 
         <activity android:name="android.accounts.GrantCredentialsPermissionActivity"
                 android:excludeFromRecents="true"
                 android:exported="true"
-                android:theme="@style/Theme.Material.Light.DialogWhenLarge"
+                android:theme="@style/Theme.Material.Light.DialogWhenLarge.GrantCredentialsPermissionActivity"
                 android:process=":ui">
         </activity>
 
         <activity android:name="android.content.SyncActivityTooManyDeletes"
-               android:theme="@style/Theme.Material.Light.Dialog"
+               android:theme="@style/Theme.Material.Light.Dialog.SyncActivityTooManyDeletes"
                android:label="@string/sync_too_many_deletes"
                android:process=":ui">
         </activity>
@@ -2903,7 +2903,7 @@
         </activity>
 
         <activity android:name="com.android.internal.app.NetInitiatedActivity"
-                android:theme="@style/Theme.Material.Light.Dialog.Alert"
+                android:theme="@style/Theme.Material.Light.Dialog.Alert.NetInitiatedActivity"
                 android:excludeFromRecents="true"
                 android:process=":ui">
         </activity>

--- a/core/res/res/values/cm_styles.xml
+++ b/core/res/res/values/cm_styles.xml
@@ -1,0 +1,29 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+     Copyright (C) 2016 The CyanogenMod Project
+
+     Licensed under the Apache License, Version 2.0 (the "License");
+     you may not use this file except in compliance with the License.
+     You may obtain a copy of the License at
+
+          http://www.apache.org/licenses/LICENSE-2.0
+
+     Unless required by applicable law or agreed to in writing, software
+     distributed under the License is distributed on an "AS IS" BASIS,
+     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+     See the License for the specific language governing permissions and
+     limitations under the License.
+-->
+<resources>
+
+    <!-- Exposed styles for framework activities -->
+    <style name="Theme.Material.Light.Dialog.HeavyWeightSwitcherActivity" />
+    <style name="Theme.Material.Light.Dialog.ChooseAccountActivity" />
+    <style name="Theme.Material.Light.Dialog.ChooseTypeAndAccountActivity" />
+    <style name="Theme.Material.Light.Dialog.ChooseAccountTypeActivity" />
+    <style name="Theme.Material.Light.Dialog.NoActionBar.CantAddAccountActivity" />
+    <style name="Theme.Material.Light.DialogWhenLarge.GrantCredentialsPermissionActivity" />
+    <style name="Theme.Material.Light.Dialog.SyncActivityTooManyDeletes" />
+    <style name="Theme.Material.Light.Dialog.Alert.NetInitiatedActivity" />
+
+</resources>


### PR DESCRIPTION
This patch creates separate themes for the various activities found
in the framework allowing for different styles for each.

Change-Id: I2035bdda83e00c04e67325e9ce855b014b2950ec
Signed-off-by: Bryan Owens <djbryan3540@gmail.com>