### PR TITLE
Add new options for call waiting response in InCallUI

### DIFF
--- a/telecomm/java/android/telecom/Call.java
+++ b/telecomm/java/android/telecom/Call.java
@@ -832,6 +832,16 @@ public final class Call {
     }
 
     /**
+     * Instructs this {@link #STATE_RINGING} {@code Call} to answer.
+     * @param videoState The video state in which to answer the call.
+     * @param callWaitingResponseType Type of response for call waiting
+     * @hide
+     */
+    public void answer(int videoState, int callWaitingResponseType) {
+        mInCallAdapter.answerCall(mTelecomCallId, videoState, callWaitingResponseType);
+    }
+
+    /**
      * Instructs this {@link #STATE_RINGING} {@code Call} to reject.
      *
      * @param rejectWithMessage Whether to reject with a text message.
@@ -1172,6 +1182,7 @@ public final class Call {
                 && !parcelableCall.getCannedSmsResponses().isEmpty()) {
             mCannedTextResponses =
                     Collections.unmodifiableList(parcelableCall.getCannedSmsResponses());
+            cannedTextResponsesChanged = true;
         }
 
         boolean videoCallChanged = parcelableCall.isVideoCallProviderChanged() &&

--- a/telecomm/java/android/telecom/InCallAdapter.java
+++ b/telecomm/java/android/telecom/InCallAdapter.java
@@ -57,6 +57,20 @@ public final class InCallAdapter {
     }
 
     /**
+     * Instructs Telecom to answer the specified call.
+     *
+     * @param callId The identifier of the call to answer.
+     * @param videoState The video state in which to answer the call.
+     * @param callWaitingResponseType Response type for call waiting.
+     */
+    public void answerCall(String callId, int videoState, int callWaitingResponseType) {
+        try {
+            mAdapter.answerCallWithCallWaitingResponse(callId, videoState, callWaitingResponseType);
+        } catch (RemoteException e) {
+        }
+    }
+
+    /**
      * Instructs Telecom to reject the specified call.
      *
      * @param callId The identifier of the call to reject.

--- a/telecomm/java/android/telecom/TelecomManager.java
+++ b/telecomm/java/android/telecom/TelecomManager.java
@@ -443,6 +443,25 @@ public class TelecomManager {
      */
     public static final int PRESENTATION_PAYPHONE = 4;
 
+    /**
+     * The following 2 constants define how the incoming call should be handled by the Telecomm
+     * server when there is already an active call.
+     */
+
+    /**
+     * Indicates that Telecom server should end the current active call when another incoming
+     * call is detected
+     * @hide
+     */
+    public static final int CALL_WAITING_RESPONSE_NO_POPUP_END_CALL = 1;
+
+    /**
+     * Indicates that Telecom server should  hold the current active call when another incoming
+     * call is detected
+     * @hide
+     */
+    public static final int CALL_WAITING_RESPONSE_NO_POPUP_HOLD_CALL = 2;
+
     private static final String TAG = "TelecomManager";
 
     private final Context mContext;

--- a/telecomm/java/com/android/internal/telecom/IInCallAdapter.aidl
+++ b/telecomm/java/com/android/internal/telecom/IInCallAdapter.aidl
@@ -64,4 +64,7 @@ oneway interface IInCallAdapter {
     void switchToOtherActiveSub(String subId);
 
     void transferCall(String callId);
+
+    void answerCallWithCallWaitingResponse(String callId, int videoState, int
+        callWaitingResponseType);
 }


### PR DESCRIPTION
When an incoming call is received while there is already an active call,
the user will be given four choices for the response:

1) Left button: hold the current call and answer incoming call
2) Bottom button: end the current call and answer the incoming call
3) Right button: decline the incoming call
4) Top button: Send a text message to the incoming caller if texting
   is enabled

The framework changes include new hidden API for sending additional
information to Telecomm service, few constants, and a bug fix.

Change-Id: I642b330d856613fafc0526eb79dd97fedba4ce6a