### PR TITLE
SystemUI: fix NPE when configuring blur layer

### DIFF
--- a/packages/SystemUI/src/com/android/systemui/statusbar/phone/StatusBarWindowManager.java
+++ b/packages/SystemUI/src/com/android/systemui/statusbar/phone/StatusBarWindowManager.java
@@ -148,7 +148,7 @@ public class StatusBarWindowManager implements KeyguardMonitor.Callback {
         } else {
             mLpChanged.flags &= ~WindowManager.LayoutParams.FLAG_SHOW_WALLPAPER;
             mLpChanged.privateFlags &= ~WindowManager.LayoutParams.PRIVATE_FLAG_KEYGUARD;
-            if (mKeyguardBlurEnabled) {
+            if (mKeyguardBlurEnabled && mKeyguardBlur != null) {
                 mKeyguardBlur.hide();
             }
         }


### PR DESCRIPTION
I noticed a NPE on my device with OOB encryption & password lockscreen
(no password required to boot).  This fixes it.

FEIJ-753

Change-Id: I303354e94be451ab65deb815ecf39cda9d6a339e