### PR TITLE
Only call uncrypt when we're encrypted

### DIFF
--- a/services/core/java/com/android/server/power/ShutdownThread.java
+++ b/services/core/java/com/android/server/power/ShutdownThread.java
@@ -630,7 +630,10 @@ public final class ShutdownThread extends Thread {
             }
         };
 
-        if (mRebootUpdate) {
+        final String cryptoStatus = SystemProperties.get("ro.crypto.state", "unsupported");
+        final boolean isEncrypted = "encrypted".equalsIgnoreCase(cryptoStatus);
+
+        if (mRebootUpdate && isEncrypted) {
             sInstance.setRebootProgress(MOUNT_SERVICE_STOP_PERCENT, null);
 
             // If it's to reboot to install update, invoke uncrypt via init service.


### PR DESCRIPTION
We were always generating a block map for encrypted update, even
when the device was not encrypted.  This leads to a spectacular
failure.  Fix this by only calling uncrypt when we're encrypted.

Additionally, only pass block.map as the update file in the case
that the device was encrypted and requires it.

NIGHTLIES-3012
Change-Id: Ia34eb5115ac4365605fd57f76179854a6042c5e4