### PR TITLE
Revert "Only show keyguard panel if on lockscreen + no activity on top"

### DIFF
--- a/packages/SystemUI/src/com/android/systemui/statusbar/phone/PhoneStatusBar.java
+++ b/packages/SystemUI/src/com/android/systemui/statusbar/phone/PhoneStatusBar.java
@@ -4538,10 +4538,6 @@ public class PhoneStatusBar extends BaseStatusBar implements DemoMode,
         return mStatusBarKeyguardViewManager != null && mStatusBarKeyguardViewManager.isSecure();
     }
 
-    public boolean isKeyguardInputRestricted() {
-        return mStatusBarKeyguardViewManager != null && mStatusBarKeyguardViewManager.isInputRestricted();
-    }
-
     public long calculateGoingToFullShadeDelay() {
         return mKeyguardFadingAwayDelay + mKeyguardFadingAwayDuration;
     }

--- a/packages/SystemUI/src/com/android/systemui/statusbar/policy/LiveLockScreenController.java
+++ b/packages/SystemUI/src/com/android/systemui/statusbar/policy/LiveLockScreenController.java
@@ -102,10 +102,10 @@ public class LiveLockScreenController {
                 }
             }
         } else {
-            if (isShowingLiveLockScreenView() && !mBar.isKeyguardInputRestricted()) {
+            if (isShowingLiveLockScreenView()) {
                 mPanelView.removeView(mLiveLockScreenView);
+                mLlsHasFocus = false;
             }
-            mLlsHasFocus = false;
         }
     }
 

--- a/services/core/java/com/android/server/wm/WindowAnimator.java
+++ b/services/core/java/com/android/server/wm/WindowAnimator.java
@@ -220,9 +220,7 @@ public class WindowAnimator {
         // Show SHOW_WHEN_LOCKED windows that turn on the screen
         allowWhenLocked |= (win.mAttrs.flags & FLAG_SHOW_WHEN_LOCKED) != 0 && win.mTurnOnScreen;
         // Show windows that use TYPE_STATUS_BAR_SUB_PANEL when locked
-        allowWhenLocked |= win.mAttrs.type == WindowManager.LayoutParams.TYPE_KEYGUARD_PANEL &&
-                winShowWhenLocked == null;
-
+        allowWhenLocked |= win.mAttrs.type == WindowManager.LayoutParams.TYPE_KEYGUARD_PANEL;
 
         if (appShowWhenLocked != null) {
             allowWhenLocked |= appShowWhenLocked == win.mAppToken


### PR DESCRIPTION
Breaks SHOW_WHEN_LOCKED for secure lockscreen + blur + LLS
CYNGNOS-3057

This reverts commit 28e023d0c621f00e357f52264baaedf72c1eeee7.

Change-Id: Iccec0129e793b910af02bf0a8f60ec9a2ca226a2