### PR TITLE
SystemServer: Do not start Atlas Service on lowram devices.

### DIFF
--- a/services/java/com/android/server/SystemServer.java
+++ b/services/java/com/android/server/SystemServer.java
@@ -460,6 +460,7 @@ public final class SystemServer {
         boolean isEmulator = SystemProperties.get("ro.kernel.qemu").equals("1");
         String externalServer = context.getResources().getString(
                 org.cyanogenmod.platform.internal.R.string.config_externalSystemServer);
+        boolean disableAtlas = SystemProperties.getBoolean("config.disable_atlas", false);
 
         try {
             Slog.i(TAG, "Reading configuration...");
@@ -960,7 +961,7 @@ public final class SystemServer {
                 mSystemServiceManager.startService(DreamManagerService.class);
             }
 
-            if (!disableNonCoreServices) {
+            if (!disableNonCoreServices && !disableAtlas) {
                 try {
                     Slog.i(TAG, "Assets Atlas Service");
                     atlas = new AssetAtlasService(context);


### PR DESCRIPTION
Provide an on/off switch to control atlas service at start-up. This
service is disabled by default on lowram devices to save memory.
Atlas service is responsible for pre-loading drawables which
can be shareable among the applications. Found that the probability
of using same drawables in different apps concurrently is very less.
However it allocates fixed size of ion buffer based on config.
So by disabling it this memory overhead can be avoided. We are safe
to disable this service as it does not block any functionality.

Change-Id: I14599125c717b61f3ea5cded376fcc1802281756