### PR TITLE
Remove use of '_' variable name

### DIFF
--- a/media/java/android/media/SRTRenderer.java
+++ b/media/java/android/media/SRTRenderer.java
@@ -165,7 +165,6 @@ class SRTTrack extends WebVttTrack {
             return;
         }
 
-        final int _ = 0;
         for (Cue cue : activeCues) {
             TextTrackCue ttc = (TextTrackCue) cue;
 
@@ -184,7 +183,8 @@ class SRTTrack extends WebVttTrack {
             parcel.writeInt(buf.length);
             parcel.writeByteArray(buf);
 
-            Message msg = mEventHandler.obtainMessage(MEDIA_TIMED_TEXT, _, _, parcel);
+            Message msg = mEventHandler.obtainMessage(MEDIA_TIMED_TEXT, 0 /* arg1 */, 0 /* arg2 */,
+                    parcel);
             mEventHandler.sendMessage(msg);
         }
         activeCues.clear();


### PR DESCRIPTION
'_' may become invalid in future versions of the Java language
and generates warnings in OpenJDK 8.

Bug: 24494019

Change-Id: Id77c8f003b0fdf295191d2d8dbd5b0b0edde2b44