### PR TITLE
Fix random crash in libhwui

### DIFF
--- a/libs/hwui/Snapshot.cpp
+++ b/libs/hwui/Snapshot.cpp
@@ -40,6 +40,7 @@ Snapshot::Snapshot()
         , mClipArea(&mClipAreaRoot) {
     transform = &mTransformRoot;
     region = nullptr;
+    mRelativeLightCenter.x = mRelativeLightCenter.y = mRelativeLightCenter.z = 0;
 }
 
 /**


### PR DESCRIPTION
On some cases (noticed from log) that there is a crash in
libhwui.so, future debug log shows that the light center position
values are nan, causing an out of bound access in hull function
in SpotShadow.cpp for parameter retPoly which assume to be of
maximum length of pointsLength only but not the case when all
points are nan.

More log shows that a Snapshot was created (new) without
mRelativeLightCenter begin set, and Layer.cpp trying to
use it by calling updateLightPosFromRenderer. Those values
are random values in stack which causing math calc based on
that value returning nan also.

Initialize mRelativeLightCenter to 0 in Snapshot.cpp to avoid the
problem.

Change-Id: I9e24f6f1f856d053d09db1b1aae100f219f2a6de