### PR TITLE
pm: Skip custom resolver use when mOnlyCore

### DIFF
--- a/services/core/java/com/android/server/pm/PackageManagerService.java
+++ b/services/core/java/com/android/server/pm/PackageManagerService.java
@@ -4730,7 +4730,7 @@ public class PackageManagerService extends IPackageManager.Stub {
 
     private boolean shouldIncludeResolveActivity(Intent intent) {
         // Don't call into AppSuggestManager before it comes up later in the SystemServer init!
-        if (!mSystemReady) {
+        if (!mSystemReady || mOnlyCore) {
             return false;
         }
         synchronized(mPackages) {


### PR DESCRIPTION
 * It just throws exceptions.

Change-Id: I503a2b787a661b3ab5c52b675e49f2eae92c9ec0