### PR TITLE
mountservice: Don't nuke all volumes when decrypting

### DIFF
--- a/services/core/java/com/android/server/MountService.java
+++ b/services/core/java/com/android/server/MountService.java
@@ -2392,8 +2392,13 @@ class MountService extends IMountService.Stub
                 // to let the UI to clear itself
                 mHandler.postDelayed(new Runnable() {
                     public void run() {
+                        // unmount the internal emulated volume first
                         try {
-                            mConnector.execute("volume", "shutdown");
+                            mConnector.execute("volume", "unmount", "emulated");
+                        } catch (NativeDaemonConnectorException e) {
+                            Slog.e(TAG, "unable to shut down internal volume", e);
+                        }
+                        try {
                             mCryptConnector.execute("cryptfs", "restart");
                         } catch (NativeDaemonConnectorException e) {
                             Slog.e(TAG, "problem executing in background", e);


### PR DESCRIPTION
 * Instead, just unmount the emulated internal volume since
   it's the only one which can prevent cryptfs from restarting.

Change-Id: I757babaf763b4ef789b165d116da0708a3530e99