### PR TITLE
Ensure DHCP requests have nonempty hostnames

### DIFF
--- a/services/net/java/android/net/dhcp/DhcpPacket.java
+++ b/services/net/java/android/net/dhcp/DhcpPacket.java
@@ -602,7 +602,12 @@ abstract class DhcpPacket {
     protected void addCommonClientTlvs(ByteBuffer buf) {
         addTlv(buf, DHCP_MAX_MESSAGE_SIZE, (short) MAX_LENGTH);
         addTlv(buf, DHCP_VENDOR_CLASS_ID, "android-dhcp-" + Build.VERSION.RELEASE);
-        addTlv(buf, DHCP_HOST_NAME, SystemProperties.get("net.hostname"));
+
+        /* the default 'android-dhcp' is there to make sure the hostname is
+         * never empty, because the DHCP standard forbids it (RFC2132, section
+         * 3.14) and certain DHCP forwarders and servers ignore such malformed
+         * requests */
+        addTlv(buf, DHCP_HOST_NAME, SystemProperties.get("net.hostname", "android-dhcp"));
     }
 
     /**


### PR DESCRIPTION
If the net.hostname property is empty or not found, Android issues
DHCP requests with an empty hostname field (option 12). RFC2132 section
3.14 prescribes a minimum length of 1 byte for the hostname.

To fix this, a generic 'android-dhcp' hostname is used as a fallback.

Change-Id: I7a92e7295f72b3255e4fba6498fb4039906eb702