### PR TITLE
sensors: Allow opting out of default batch size

### DIFF
--- a/core/res/res/values/config.xml
+++ b/core/res/res/values/config.xml
@@ -2712,6 +2712,11 @@
     <!-- Whether to persist the notification for when a usb drive device is plugged in -->
     <bool name="config_persistUsbDriveNotification">false</bool>
 
+    <!-- Certain sensor firmwares break with having a batch
+         size set. By setting this to false, devices can opt
+         out of setting a batch size, which fixes rotation. -->
+    <bool name="config_useDefaultBatchingForAccel">true</bool>
+
     <!-- Older rotation sensors are not setting event.timestamp correctly. Setting to
          true will use SystemClock.elapsedRealtimeNanos() to set timestamp. -->
     <bool name="config_useSystemClockforRotationSensor">false</bool>

--- a/core/res/res/values/symbols.xml
+++ b/core/res/res/values/symbols.xml
@@ -2732,6 +2732,8 @@
   <java-symbol type="string" name="adb_both_active_notification_title" />
   <java-symbol type="string" name="adb_active_generic_notification_message" />
 
+  <java-symbol type="bool" name="config_useDefaultBatchingForAccel" />
+
   <java-symbol type="bool" name="config_useSystemClockforRotationSensor" />
 
   <java-symbol type="string" name="power_key_emergency_number" />

--- a/services/core/java/com/android/server/policy/WindowOrientationListener.java
+++ b/services/core/java/com/android/server/policy/WindowOrientationListener.java
@@ -56,6 +56,7 @@ public abstract class WindowOrientationListener {
     private boolean mEnabled;
     private int mRate;
     private String mSensorType;
+    private boolean mUseDefaultBatchingForAccel;
     private boolean mUseSystemClockforRotationSensor;
     private Sensor mSensor;
     private OrientationJudge mOrientationJudge;
@@ -91,6 +92,9 @@ public abstract class WindowOrientationListener {
         mRate = rate;
         mSensor = mSensorManager.getDefaultSensor(Sensor.TYPE_DEVICE_ORIENTATION);
 
+        mUseDefaultBatchingForAccel = context.getResources().getBoolean(
+            com.android.internal.R.bool.config_useDefaultBatchingForAccel);
+
         mUseSystemClockforRotationSensor = context.getResources().getBoolean(
                 com.android.internal.R.bool.config_useSystemClockforRotationSensor);
 
@@ -123,7 +127,8 @@ public abstract class WindowOrientationListener {
                     Slog.d(TAG, "WindowOrientationListener enabled");
                 }
                 mOrientationJudge.resetLocked();
-                if (mSensor.getType() == Sensor.TYPE_ACCELEROMETER) {
+                if (mSensor.getType() == Sensor.TYPE_ACCELEROMETER
+                    && mUseDefaultBatchingForAccel) {
                     mSensorManager.registerListener(
                             mOrientationJudge, mSensor, mRate, DEFAULT_BATCH_LATENCY, mHandler);
                 } else {


### PR DESCRIPTION
* In commit d49b1ee0de1eeb2f7370bf2839e7c707fe008b37,
  Google introduced a default batch size for the
  accelerometer, meant for Android Wear devices
* For some bizarre reason, this change breaks
  rotation on certain devices.
* Specifically, this behavior has been noticed
  by devices using Samsung's Sensorhub firmware
* As a result, add an overlay to allow opting out
  of this default accelerometer batch size in
  order to fix rotation on certain Samsung devices
* Thanks to Martin Bouchet <tincho5588@gmail.com>
  for pointing me to the offending commit in fw/b

Change-Id: I8769147e1b1553a8fbad03340745a7e7377b8510
Signed-off-by: Paul Keith <javelinanddart@gmail.com>