### PR TITLE
NetworkManagement : Add ability to restrict app data/wifi usage

### DIFF
--- a/core/java/android/net/NetworkPolicyManager.java
+++ b/core/java/android/net/NetworkPolicyManager.java
@@ -48,6 +48,10 @@ public class NetworkPolicyManager {
     public static final int POLICY_REJECT_METERED_BACKGROUND = 0x1;
     /** Allow network use (metered or not) in the background in battery save mode. */
     public static final int POLICY_ALLOW_BACKGROUND_BATTERY_SAVE = 0x2;
+    /** Reject application network traffic on wifi network **/
+    public static final int POLICY_REJECT_ON_WIFI = 0x8000;
+    /** Reject application network traffic on cellular network **/
+    public static final int POLICY_REJECT_ON_DATA = 0x10000;
 
     /*
      * Rules defining whether an uid has access to a network given its type (metered / non-metered).

--- a/core/java/android/os/INetworkManagementService.aidl
+++ b/core/java/android/os/INetworkManagementService.aidl
@@ -455,4 +455,10 @@ interface INetworkManagementService
     int removeRoutesFromLocalNetwork(in List<RouteInfo> routes);
 
     void setAllowOnlyVpnForUids(boolean enable, in UidRange[] uidRanges);
+
+    /**
+     * Restrict UID from accessing data/wifi
+     */
+    void restrictAppOnData(int uid, boolean restrict);
+    void restrictAppOnWifi(int uid, boolean restrict);
 }

--- a/services/core/java/com/android/server/net/NetworkPolicyManagerService.java
+++ b/services/core/java/com/android/server/net/NetworkPolicyManagerService.java
@@ -48,6 +48,8 @@ import static android.net.NetworkPolicyManager.FIREWALL_RULE_DEFAULT;
 import static android.net.NetworkPolicyManager.FIREWALL_RULE_DENY;
 import static android.net.NetworkPolicyManager.POLICY_NONE;
 import static android.net.NetworkPolicyManager.POLICY_REJECT_METERED_BACKGROUND;
+import static android.net.NetworkPolicyManager.POLICY_REJECT_ON_DATA;
+import static android.net.NetworkPolicyManager.POLICY_REJECT_ON_WIFI;
 import static android.net.NetworkPolicyManager.RULE_ALLOW_ALL;
 import static android.net.NetworkPolicyManager.RULE_ALLOW_METERED;
 import static android.net.NetworkPolicyManager.MASK_METERED_NETWORKS;
@@ -3000,6 +3002,13 @@ public class NetworkPolicyManagerService extends INetworkPolicyManager.Stub {
         final boolean isWhitelisted = mRestrictBackgroundWhitelistUids.get(uid);
         final int oldRule = oldUidRules & MASK_METERED_NETWORKS;
         int newRule = RULE_NONE;
+
+        try {
+            mNetworkManager.restrictAppOnWifi(uid, (uidPolicy & POLICY_REJECT_ON_WIFI) != 0);
+            mNetworkManager.restrictAppOnData(uid, (uidPolicy & POLICY_REJECT_ON_DATA) != 0);
+        } catch (RemoteException e) {
+            // ignored; service lives in system_server
+        }
 
         // First step: define the new rule based on user restrictions and foreground state.
         if (isForeground) {


### PR DESCRIPTION
CYAN-3976
CRACKLING-834

Changes in cm-14.1:

*) Substitute marshmallow LISTEN_DATA_CONNECTION_REAL_TIME_INFO
   PhoneStateListener() for a CONNECTIVITY_ACTION broadcast
   receiver that unregisters itself once mDataInterfaceName
   has been set.
*) Convert usage of Map<Integer, Boolean> into SparseBooleanArray

Change-Id: Iaa0483d0ad64511184f0f31d93552a93fbab6dd0