### PR TITLE
SystemUI: PowerNotification: Add up button to fragment

### DIFF
--- a/packages/SystemUI/src/com/android/systemui/tuner/PowerNotificationControlsFragment.java
+++ b/packages/SystemUI/src/com/android/systemui/tuner/PowerNotificationControlsFragment.java
@@ -24,6 +24,7 @@ import android.app.Fragment;
 import android.os.Bundle;
 import android.provider.Settings;
 import android.view.LayoutInflater;
+import android.view.MenuItem;
 import android.view.View;
 import android.view.ViewGroup;
 import android.widget.Switch;
@@ -69,6 +70,17 @@ public class PowerNotificationControlsFragment extends Fragment {
                         : getString(R.string.switch_bar_off));
             }
         });
+
+        getActivity().getActionBar().setDisplayHomeAsUpEnabled(true);
+    }
+
+    @Override
+    public boolean onOptionsItemSelected(MenuItem item) {
+        if (item.getItemId() == android.R.id.home) {
+            getActivity().onBackPressed();
+            return true;
+        }
+        return super.onOptionsItemSelected(item);
     }
 
     @Override


### PR DESCRIPTION
Currently, there is no up button for the user to navigate
back to "Configure notifications" after entering "Power notification
controls".

Add the up button.

Change-Id: Ia983cd9453da4e3354aac9f3928ffcb5985226e5