### PR TITLE
SystemUI: Fix the unlock sound played repeatedly

### DIFF
--- a/packages/SystemUI/src/com/android/systemui/keyguard/KeyguardViewMediator.java
+++ b/packages/SystemUI/src/com/android/systemui/keyguard/KeyguardViewMediator.java
@@ -1776,7 +1776,9 @@ public class KeyguardViewMediator extends SystemUI {
             // only play "unlock" noises if not on a call (since the incall UI
             // disables the keyguard)
             if (TelephonyManager.EXTRA_STATE_IDLE.equals(mPhoneState)) {
-                playSounds(false);
+                if (mShowing && mDeviceInteractive) {
+                    playSounds(false);
+                }
             }
 
             mWakeAndUnlocking = false;


### PR DESCRIPTION
Sometimes keyguardDone() may be invoked from PhoneWindowManager many times
in a short time, especially when app works with FLAG_DISMISS_KEYGUARD.

Make sure the unlock sound is only played when keyguard is showing and the
screen is on.

Fixes Lineage: BUGBASH-56

Change-Id: I396588579a3be3b3210e619179d2a57211904644
CRs-Fixed: 900840