### PR TITLE
Add tile information to ACTION_QS_TILE_PREFERENCES intent

### DIFF
--- a/core/java/android/service/quicksettings/TileService.java
+++ b/core/java/android/service/quicksettings/TileService.java
@@ -130,6 +130,11 @@ public class TileService extends Service {
      */
     public static final String EXTRA_COMPONENT = "android.service.quicksettings.extra.COMPONENT";
 
+    /**
+     * @hide
+     */
+    public static final String EXTRA_STATE = "state";
+
     private final H mHandler = new H(Looper.getMainLooper());
 
     private boolean mListening = false;

--- a/packages/SystemUI/src/com/android/systemui/qs/external/CustomTile.java
+++ b/packages/SystemUI/src/com/android/systemui/qs/external/CustomTile.java
@@ -232,6 +232,8 @@ public class CustomTile extends QSTile<QSTile.State> implements TileChangeListen
         i.setPackage(mComponent.getPackageName());
         i = resolveIntent(i);
         if (i != null) {
+            i.putExtra(TileService.EXTRA_COMPONENT, mComponent);
+            i.putExtra(TileService.EXTRA_STATE, mTile.getState());
             return i;
         }
         return new Intent(Settings.ACTION_APPLICATION_DETAILS_SETTINGS).setData(


### PR DESCRIPTION
One application can provide two or more custom Quick Settings tiles.
But there is no way to know which tile is long-pressed from application
side because ACTION_QS_TILE_PREFERENCES intent that is sent when
long-pressed doesn't have any additional information. So the component
name and state of the tile should be added to the intent.

Bug: 34832801
Test: manual - long press a custom tile

Change-Id: Iaa884cd944f19a2f007cbde645e8f8b1198bffb7