### PR TITLE
PowerManager: Bring back the compatibility with AOSP

### DIFF
--- a/services/core/jni/com_android_server_power_PowerManagerService.cpp
+++ b/services/core/jni/com_android_server_power_PowerManagerService.cpp
@@ -70,8 +70,7 @@ static bool checkAndClearExceptionFromCallback(JNIEnv* env, const char* methodNa
 void android_server_PowerManagerService_userActivity(nsecs_t eventTime, int32_t eventType) {
     // Tell the power HAL when user activity occurs.
     if (gPowerModule && gPowerModule->powerHint) {
-        int data_param = 0;
-        gPowerModule->powerHint(gPowerModule, POWER_HINT_INTERACTION, &data_param);
+        gPowerModule->powerHint(gPowerModule, POWER_HINT_INTERACTION, NULL);
     }
 
     if (gPowerManagerServiceObj) {
@@ -145,11 +144,25 @@ static void nativeSetAutoSuspend(JNIEnv* /* env */, jclass /* clazz */, jboolean
     }
 }
 
+static bool isCustomHint(jint hintId) {
+    switch (hintId) {
+        case POWER_HINT_CPU_BOOST:
+        case POWER_HINT_SET_PROFILE:
+            return true;
+        default:
+            return false;
+    }
+}
+
 static void nativeSendPowerHint(JNIEnv *env, jclass clazz, jint hintId, jint data) {
     int data_param = data;
 
     if (gPowerModule && gPowerModule->powerHint) {
-        gPowerModule->powerHint(gPowerModule, (power_hint_t)hintId, &data_param);
+        if (data || isCustomHint(hintId)) {
+            gPowerModule->powerHint(gPowerModule, (power_hint_t)hintId, &data_param);
+        } else {
+            gPowerModule->powerHint(gPowerModule, (power_hint_t)hintId, NULL);
+        }
     }
 }
 


### PR DESCRIPTION
We changed the behavior of setPowerHint() so that our HALs could
easily handle the POWER_HINT_SET_PROFILE hint. However, this silently
broke the compatibility with AOSP. Restore the original code and
handle differently only our custom hints.

Change-Id: Ifeaae04fff8cafb4df3becc87dfdbeae48006ee3