### PR TITLE
SystemUI: Misc fixes for right (custom) lockscreen shortcuts

### DIFF
--- a/packages/SystemUI/src/com/android/systemui/statusbar/phone/KeyguardBottomAreaView.java
+++ b/packages/SystemUI/src/com/android/systemui/statusbar/phone/KeyguardBottomAreaView.java
@@ -262,7 +262,6 @@ public class KeyguardBottomAreaView extends FrameLayout implements View.OnClickL
         mCameraImageView.setContentDescription(contentDescription);
         mCameraImageView.setDefaultFilter(shouldGrayScale ? mGrayScaleFilter : null);
         updateCameraVisibility();
-        updateLeftButtonVisibility();
     }
 
     private void initAccessibility() {
@@ -291,7 +290,7 @@ public class KeyguardBottomAreaView extends FrameLayout implements View.OnClickL
         lp.width = getResources().getDimensionPixelSize(R.dimen.keyguard_affordance_width);
         lp.height = getResources().getDimensionPixelSize(R.dimen.keyguard_affordance_height);
         mCameraImageView.setLayoutParams(lp);
-        mCameraImageView.setImageDrawable(mContext.getDrawable(R.drawable.ic_camera_alt_24dp));
+        updateRightAffordanceIcon();
 
         lp = mLockIcon.getLayoutParams();
         lp.width = getResources().getDimensionPixelSize(R.dimen.keyguard_affordance_width);
@@ -333,6 +332,7 @@ public class KeyguardBottomAreaView extends FrameLayout implements View.OnClickL
     public void setUserSetupComplete(boolean userSetupComplete) {
         mUserSetupComplete = userSetupComplete;
         updateCameraVisibility();
+        updateRightAffordanceIcon();
         updateLeftButtonVisibility();
         updateLeftAffordanceIcon();
     }
@@ -827,8 +827,7 @@ public class KeyguardBottomAreaView extends FrameLayout implements View.OnClickL
 
         @Override
         public void onUserUnlocked() {
-            inflateCameraPreview();
-            updateCameraVisibility();
+            updateRightAffordance();
             updateLeftAffordance();
         }
     };
@@ -848,9 +847,14 @@ public class KeyguardBottomAreaView extends FrameLayout implements View.OnClickL
         updateLeftPreview();
     }
 
+    public void updateRightAffordance() {
+        updateRightAffordanceIcon();
+        inflateCameraPreview();
+    }
+
     public void onKeyguardShowingChanged() {
         updateLeftAffordance();
-        inflateCameraPreview();
+        updateRightAffordance();
     }
 
     private String getIndexHint(LockscreenShortcutsHelper.Shortcuts shortcut) {


### PR DESCRIPTION
In the current implementation only the left target is being properly
updated via 'updateLeftAffordance'. Implement 'updateRightAffordance'
to handle the right target in a similar fashion.

This fixes (1) a rare scenario where the right target would be color-
ed black instead of gray and (2) the launch animation background for
custom targets not adopting the icon color of the selected app.

BUGBASH-353
BUGBASH-356

Change-Id: I556fc7316c3b646bf004b4f0a510fbc3736b2bd8