### PR TITLE
sensors: Allow opting out of default batch size

### DIFF
--- a/core/res/res/values/config.xml
+++ b/core/res/res/values/config.xml
@@ -2710,6 +2710,11 @@
     <string-array translatable="false" name="config_defaultPinnerServiceFiles">
     </string-array>
 
+    <!-- Certain sensor firmwares break with having a batch
+         size set. By setting this to false, devices can opt
+         out of setting a batch size, which fixes rotation. -->
+    <bool name="config_useDefaultBatchingForAccel">true</bool>
+
     <!-- True if camera app should be pinned via Pinner Service -->
     <bool name="config_pinnerCameraApp">false</bool>
 

--- a/core/res/res/values/symbols.xml
+++ b/core/res/res/values/symbols.xml
@@ -2749,6 +2749,8 @@
   <java-symbol type="layout" name="unsupported_display_size_dialog_content" />
   <java-symbol type="string" name="unsupported_display_size_message" />
 
+  <java-symbol type="bool" name="config_useDefaultBatchingForAccel" />
+
   <java-symbol type="layout" name="notification_material_action_emphasized" />
 
   <!-- Package name for the device provisioning package -->

--- a/services/core/java/com/android/server/policy/WindowOrientationListener.java
+++ b/services/core/java/com/android/server/policy/WindowOrientationListener.java
@@ -56,6 +56,7 @@ public abstract class WindowOrientationListener {
     private boolean mEnabled;
     private int mRate;
     private String mSensorType;
+    private boolean mUseDefaultBatchingForAccel;
     private boolean mUseSystemClockforRotationSensor;
     private Sensor mSensor;
     private OrientationJudge mOrientationJudge;
@@ -90,6 +91,9 @@ public abstract class WindowOrientationListener {
         mSensorManager = (SensorManager)context.getSystemService(Context.SENSOR_SERVICE);
         mRate = rate;
         mSensor = mSensorManager.getDefaultSensor(Sensor.TYPE_DEVICE_ORIENTATION);
+
+        mUseDefaultBatchingForAccel = context.getResources().getBoolean(
+            com.android.internal.R.bool.config_useDefaultBatchingForAccel);
 
         mUseSystemClockforRotationSensor = context.getResources().getBoolean(
                 com.android.internal.R.bool.config_useSystemClockforRotationSensor);
@@ -137,7 +141,7 @@ public abstract class WindowOrientationListener {
                         + clearCurrentRotation);
             }
             mOrientationJudge.resetLocked(clearCurrentRotation);
-            if (mSensor.getType() == Sensor.TYPE_ACCELEROMETER) {
+            if (mSensor.getType() == Sensor.TYPE_ACCELEROMETER && mUseDefaultBatchingForAccel) {
                 mSensorManager.registerListener(
                         mOrientationJudge, mSensor, mRate, DEFAULT_BATCH_LATENCY, mHandler);
             } else {


### PR DESCRIPTION
* In commit d49b1ee0de1eeb2f7370bf2839e7c707fe008b37,
  Google introduced a default batch size for the
  accelerometer, meant for Android Wear devices
* For some bizarre reason, this change breaks
  rotation on certain devices.
* Specifically, this behavior has been noticed
  by devices using Samsung's Sensorhub firmware
* As a result, add an overlay to allow opting out
  of this default accelerometer batch size in
  order to fix rotation on certain Samsung devices
* Thanks to Martin Bouchet <tincho5588@gmail.com>
  for pointing me to the offending commit in fw/b

Change-Id: I8769147e1b1553a8fbad03340745a7e7377b8510
Signed-off-by: Paul Keith <javelinanddart@gmail.com>