### PR TITLE
Don't crash when checking if components are protected

### DIFF
--- a/services/core/java/com/android/server/am/ActivityStarter.java
+++ b/services/core/java/com/android/server/am/ActivityStarter.java
@@ -2191,7 +2191,8 @@ class ActivityStarter {
 
     private boolean shouldExcludeFromRecents(final Intent intent, final int userId)
             throws RemoteException {
-        return AppGlobals.getPackageManager().isComponentProtected(
-                null, -1, intent.getComponent(), userId);
+        return intent.getComponent() != null &&
+                AppGlobals.getPackageManager().isComponentProtected(
+                        null, -1, intent.getComponent(), userId);
     }
 }


### PR DESCRIPTION
intent.getComponent() can be null, but isComponentProtected() expects
a valid object. Add a null pointer check and don't treat the app as
protected if null.

Fixes 15360dfe60a2c81187e4edcaf08679100260e2f9
("Always hide protected apps from the recent tasks list")

Change-Id: I2e0ccdfb9ded7aa32305bc2ac97e0950940d186b