### PR TITLE
SystemUI: Hide ambient display tile if device does not support it

### DIFF
--- a/packages/SystemUI/src/com/android/systemui/qs/tiles/AmbientDisplayTile.java
+++ b/packages/SystemUI/src/com/android/systemui/qs/tiles/AmbientDisplayTile.java
@@ -19,8 +19,11 @@ package com.android.systemui.qs.tiles;
 
 import android.content.Context;
 import android.content.Intent;
+import android.os.Build;
+import android.os.SystemProperties;
 import android.provider.Settings;
 import android.provider.Settings.Secure;
+import android.text.TextUtils;
 
 import com.android.systemui.qs.SecureSetting;
 import com.android.systemui.qs.QSTile;
@@ -44,6 +47,15 @@ public class AmbientDisplayTile extends QSTile<QSTile.BooleanState> {
                 handleRefreshState(value);
             }
         };
+    }
+
+    @Override
+    public boolean isAvailable() {
+        String name = Build.IS_DEBUGGABLE ? SystemProperties.get("debug.doze.component") : null;
+        if (TextUtils.isEmpty(name)) {
+            name = mContext.getString(com.android.internal.R.string.config_dozeComponent);
+        }
+        return !TextUtils.isEmpty(name);
     }
 
     @Override


### PR DESCRIPTION
* Add a check similar to the Settings app

Change-Id: I603cd28b8dd1fadff9ffcfb6953c7b72514b5857