### PR TITLE
Core: Battery warning levels are inclusive, not exclusive

### DIFF
--- a/services/core/java/com/android/server/BatteryService.java
+++ b/services/core/java/com/android/server/BatteryService.java
@@ -982,7 +982,7 @@ public final class BatteryService extends SystemService {
             if (!mLightEnabled) {
                 // No lights if explicitly disabled
                 mBatteryLight.turnOff();
-            } else if (level < mLowBatteryWarningLevel) {
+            } else if (level <= mLowBatteryWarningLevel) {
                 mBatteryLight.setModes(mNotificationLedBrightnessLevel,
                         mMultipleLedsEnabled);
                 if (status == BatteryManager.BATTERY_STATUS_CHARGING) {


### PR DESCRIPTION
* Instead of checking for the current level to be smaller than the warning
  level, already react when the warning level is reached
* Simply change of '<' to '<='

Bugbash-1100

Change-Id: Ib35b154b6117f7e26b4a3a5aee9254dda3adda12