### PR TITLE
Revert "Always hide protected apps from the recent tasks list"

### DIFF
--- a/services/core/java/com/android/server/am/ActivityStarter.java
+++ b/services/core/java/com/android/server/am/ActivityStarter.java
@@ -277,7 +277,7 @@ class ActivityStarter {
             }
         }
 
-        int launchFlags = intent.getFlags();
+        final int launchFlags = intent.getFlags();
 
         if ((launchFlags & Intent.FLAG_ACTIVITY_FORWARD_RESULT) != 0 && sourceRecord != null) {
             // Transfer the result target from the source activity to the new
@@ -384,16 +384,6 @@ class ActivityStarter {
                 Slog.w(TAG, "Failure checking protected apps status", e);
                 err = ActivityManager.START_PROTECTED_APP;
             }
-        }
-
-        try {
-            if (shouldExcludeFromRecents(intent, userId)) {
-                launchFlags |= FLAG_ACTIVITY_EXCLUDE_FROM_RECENTS;
-                intent.setFlags(launchFlags);
-            }
-        } catch (RemoteException e) {
-            Slog.w(TAG, "Failure checking protected apps status", e);
-            err = ActivityManager.START_PROTECTED_APP;
         }
 
         final ActivityStack resultStack = resultRecord == null ? null : resultRecord.task.stack;
@@ -826,15 +816,6 @@ class ActivityStarter {
                 e.printStackTrace();
             }
 
-            try {
-                if (shouldExcludeFromRecents(intent, userId)) {
-                    startFlags |= FLAG_ACTIVITY_EXCLUDE_FROM_RECENTS;
-                    intent.setFlags(startFlags);
-                }
-            } catch (RemoteException e) {
-                Slog.w(TAG, "Failure checking protected apps status", e);
-            }
-
             final int realCallingPid = Binder.getCallingPid();
             final int realCallingUid = Binder.getCallingUid();
             int callingPid;
@@ -1117,14 +1098,6 @@ class ActivityStarter {
             }
         } catch (RemoteException e) {
             e.printStackTrace();
-        }
-
-        try {
-            if (shouldExcludeFromRecents(r.intent, r.userId)) {
-                mLaunchFlags |= FLAG_ACTIVITY_EXCLUDE_FROM_RECENTS;
-            }
-        } catch (RemoteException e) {
-            Slog.w(TAG, "Failure checking protected apps status", e);
         }
 
         computeLaunchingTaskFlags();
@@ -2187,12 +2160,5 @@ class ActivityStarter {
                 mPendingActivityLaunches.remove(palNdx);
             }
         }
-    }
-
-    private boolean shouldExcludeFromRecents(final Intent intent, final int userId)
-            throws RemoteException {
-        return intent.getComponent() != null &&
-                AppGlobals.getPackageManager().isComponentProtected(
-                        null, -1, intent.getComponent(), userId);
     }
 }


### PR DESCRIPTION
This doesn't always have the desired effect. For example, CMParts is
now a protected component manager and can start protected activities
without requiring any authentication. This change seems to undo the
effect of FLAG_ACTIVITY_NEW_TASK that CMParts sets when it starts a
protected component, therefore, even though no new entry is added to
the recents list, the protected component replaces the entry for
CMParts. This is equivalent to adding an entry for the app to the
recents list. Forcing FLAG_ACTIVITY_NEW_TASK appears to have desired
effect (no entry for the protected app in recents), but this change
would be too intrusive and it could potentially break something else.
Setting the proper flags from the protected component manager is
probably a safer option, even though it would not be able to stop
apps from creating new entries in recents themselves.

This reverts commit 15360dfe60a2c81187e4edcaf08679100260e2f9.

Change-Id: Ie54cb6c6ddc1d1156076bce4b7ce9a5811df1460