### PR TITLE
SystemUI: Profiles tile should require authentication

### DIFF
--- a/packages/SystemUI/src/com/android/systemui/qs/tiles/ProfilesTile.java
+++ b/packages/SystemUI/src/com/android/systemui/qs/tiles/ProfilesTile.java
@@ -65,13 +65,7 @@ public class ProfilesTile extends QSTile<QSTile.State> implements KeyguardMonito
         mProfileManager = ProfileManager.getInstance(mContext);
         mObserver = new ProfilesObserver(mHandler);
         mKeyguardMonitor = host.getKeyguardMonitor();
-        mKeyguardMonitor.addCallback(this);
         mDetailAdapter = new ProfileDetailAdapter();
-    }
-
-    @Override
-    protected void handleDestroy() {
-        mKeyguardMonitor.removeCallback(this);
     }
 
     @Override
@@ -91,6 +85,11 @@ public class ProfilesTile extends QSTile<QSTile.State> implements KeyguardMonito
 
     @Override
     protected void handleClick() {
+        if (mKeyguardMonitor.isSecure() && mKeyguardMonitor.isShowing()) {
+            mHost.startRunnableDismissingKeyguard(() ->
+                showDetail(true));
+            return;
+        }
         showDetail(true);
     }
 
@@ -147,10 +146,12 @@ public class ProfilesTile extends QSTile<QSTile.State> implements KeyguardMonito
             filter.addAction(ProfileManager.INTENT_ACTION_PROFILE_SELECTED);
             filter.addAction(ProfileManager.INTENT_ACTION_PROFILE_UPDATED);
             mContext.registerReceiver(mReceiver, filter);
+            mKeyguardMonitor.addCallback(this);
             refreshState();
         } else {
             mObserver.endObserving();
             mContext.unregisterReceiver(mReceiver);
+            mKeyguardMonitor.removeCallback(this);
         }
     }
 


### PR DESCRIPTION
A profile with the option to disable secure lockscreen could be
used to bypass the lockscreen security.
Require the user to unlock their device when tapping on the profile
quick tile.

BUGBASH-1095

Change-Id: I9d63fcd9b1e3f47c9ca3374806d5ef05fe9ff32b
Signed-off-by: Joey Rizzoli <joey@lineageos.org>